### PR TITLE
Fix issue if id_rsa key is not available

### DIFF
--- a/lib/dokkufy/server.rb
+++ b/lib/dokkufy/server.rb
@@ -16,7 +16,11 @@ module Dokkufy
 
     def setup_key
       user = `echo $USER`
-      command = "cat ~/.ssh/id_rsa.pub | ssh #{username}@#{hostname} 'sudo sshcommand acl-add dokku #{user}'"
+      public_key = "id_rsa.pub"
+      until File.exists?(File.expand_path("~/.ssh/#{public_key}")) do
+        public_key = ask "Enter public key file name(e.g. id_rsa.pub):"
+      end
+      command = "cat ~/.ssh/#{public_key} | ssh #{username}@#{hostname} 'sudo sshcommand acl-add dokku #{user}'"
       system command
     end
 


### PR DESCRIPTION
I didnt have id_rsa public key file in my .ssh directory which caused the gem to break.I have added a simple check which lets the user select which public key he wants to use. 
