### PR TITLE
Changes the Plugin listing page

### DIFF
--- a/lib/dokkufy/info.rb
+++ b/lib/dokkufy/info.rb
@@ -1,5 +1,5 @@
 module Dokkufy
-  VERSION = "0.2.0"                 unless defined? Dokkufy::VERSION
+  VERSION = "0.2.1"                 unless defined? Dokkufy::VERSION
   NAME = "dokkufy"                  unless defined? Dokkufy::NAME
   DESCRIPTION = "Dokku Provisioning Made Easy" unless defined? Dokkufy::DESCRIPTION
 end

--- a/lib/dokkufy/plugin.rb
+++ b/lib/dokkufy/plugin.rb
@@ -23,7 +23,7 @@ module Dokkufy
 
     def self.all with_notes = false
       return @plugins if @plugins
-      open("https://github.com/progrium/dokku/wiki/Plugins") do |f|
+      open("http://progrium.viewdocs.io/dokku/plugins") do |f|
         hp = Hpricot(f)
         plugins = hp.search("tbody tr td").each_slice(3)
         @plugins = plugins.each_with_index.map do |plugin, index|


### PR DESCRIPTION
The Plugins listing page has moved from the Dokku
GitHub page to http://progrium.viewdocs.io/dokku/plugins.
This commit updates Dokkufy to use this new location.